### PR TITLE
Fix: Corrige dos bugs en el estimador y cálculo de costos

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,8 @@
   "param_map": {
     "material": {
       "TST": "TEJA SENCILLA",
-      "PANEL": "PANEL SANDWICH"
+      "PANEL": "PANEL SANDWICH",
+      "PANEL SANDWICH": "PANEL SANDWICH"
     },
     "tipo": {
       "CUBIERTA": "INSTALACION",

--- a/procesador_csv.py
+++ b/procesador_csv.py
@@ -254,6 +254,10 @@ def process_apus_csv_v2(path: str) -> pd.DataFrame:
             if pd.notna(last_numeric_part):
                 valor_total = last_numeric_part
 
+        if (pd.isna(valor_total) or valor_total == 0) and pd.notna(cantidad) and pd.notna(precio_unit):
+            if cantidad > 0 and precio_unit > 0:
+                valor_total = cantidad * precio_unit
+
         if pd.isna(cantidad) and "%" in parts[2]:
             jornal_total = to_numeric_safe(parts[3])
             if pd.notna(valor_total) and pd.notna(jornal_total) and jornal_total > 0:


### PR DESCRIPTION
Este commit soluciona dos problemas críticos:

1.  **Estimador Rápido con 'PANEL SANDWICH':** Se ha añadido el mapeo necesario en `config.json` para que la selección de "PANEL SANDWICH" en el estimador rápido funcione correctamente y encuentre los APUs correspondientes.

2.  **Costo de 'MANO DE OBRA' incorrecto:** Se ha refactorizado la función `parse_data_line` en `procesador_csv.py` para ser más robusta. Ahora, si el `valor_total` de un insumo es nulo o cero, se recalcula a partir de la `cantidad` y el `precio_unitario` si estos son válidos. Esto corrige el problema de costos en $0 en el modal de detalle de APU.