### PR TITLE
feat: Create interactive web prototype for APU_filter v2

### DIFF
--- a/prototipo_v2/index.html
+++ b/prototipo_v2/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>APU_filter v2 - Prototipo</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>APU_filter v2</h1>
+    </header>
+    <div class="container">
+        <main>
+            <div class="tabs">
+                <button class="tab-link active" data-tab="simulador">Simulador de Costos</button>
+            <button class="tab-link" data-tab="organizador">Organizador y Resúmenes</button>
+            <button class="tab-link" data-tab="estimador">Estimador Rápido</button>
+        </div>
+
+        <div id="simulador" class="tab-content active">
+            <h2>Simulador de Costos</h2>
+            <p>Contenido del simulador de costos (vista de acordeón agrupado).</p>
+        </div>
+
+        <div id="organizador" class="tab-content">
+            <h2>Organizador y Resúmenes</h2>
+            <p>Contenido del organizador y resúmenes (tabla editable y tarjetas de resumen).</p>
+        </div>
+
+        <div id="estimador" class="tab-content">
+            <h2>Estimador Rápido</h2>
+            <div class="estimator-form">
+                <div class="form-group">
+                    <label for="material-input">Material a Instalar</label>
+                    <div class="combobox-wrapper">
+                        <input type="text" id="material-input" class="combobox" placeholder="Escribe o selecciona un material">
+                        <div class="combobox-options">
+                            <div class="combobox-option" data-value="TST">TST</div>
+                            <div class="combobox-option" data-value="PANEL SANDWICH">PANEL SANDWICH</div>
+                            <div class="combobox-option" data-value="CUBIERTA TRASLUCIDA">CUBIERTA TRASLUCIDA</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="quantity">Cantidad (m2)</label>
+                    <input type="number" id="quantity" placeholder="Ej: 100">
+                </div>
+                <button id="estimate-btn">Estimar</button>
+            </div>
+            <div class="estimation-results">
+                <h3>Resultados de la Estimación</h3>
+                <div id="results-output">
+                    <p>Los resultados de la estimación aparecerán aquí.</p>
+                </div>
+            </div>
+        </div>
+    </main>
+    </div>
+    <script src="script.js"></script>
+
+    <!-- Modal for New Material Suggestion -->
+    <div id="suggest-material-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h2 id="modal-title">Sugerir Nuevo Material: "..."</h2>
+            <p>Hemos detectado un nuevo material. Para poder estimar su costo, por favor, selecciona un APU de mano de obra existente como base de cálculo. Tu sugerencia nos ayudará a mejorar APU Filter.</p>
+            <div class="form-group">
+                <label for="apu-base-select">Seleccionar APU de Mano de Obra Base</label>
+                <select id="apu-base-select">
+                    <option value="1">MANO DE OBRA INSTALACIÓN TEJA SENCILLA CUADRILLA DE 5</option>
+                    <option value="2">MANO DE OBRA INSTALACIÓN PANEL SANDWICH CUADRILLA DE 6</option>
+                    <option value="3">MANO DE OBRA INSTALACIÓN CUBIERTA TRASLUCIDA CUADRILLA DE 4</option>
+                </select>
+            </div>
+            <div class="modal-actions">
+                <button id="use-apu-btn" class="primary">[ Usar APU Base y Estimar ]</button>
+                <button id="cancel-btn" class="secondary">[ Cancelar ]</button>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/prototipo_v2/script.js
+++ b/prototipo_v2/script.js
@@ -1,0 +1,134 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Tab switching logic
+    const tabs = document.querySelectorAll('.tab-link');
+    const tabContents = document.querySelectorAll('.tab-content');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const target = document.getElementById(tab.dataset.tab);
+
+            tabs.forEach(t => t.classList.remove('active'));
+            tab.classList.add('active');
+
+            tabContents.forEach(content => content.classList.remove('active'));
+            target.classList.add('active');
+        });
+    });
+
+    // Combobox logic
+    const comboboxInput = document.getElementById('material-input');
+    const comboboxOptionsContainer = document.querySelector('.combobox-options');
+    const comboboxOptions = document.querySelectorAll('.combobox-option');
+
+    comboboxInput.addEventListener('focus', () => {
+        comboboxOptionsContainer.style.display = 'block';
+    });
+
+    comboboxInput.addEventListener('blur', () => {
+        // Delay hiding to allow click on option
+        setTimeout(() => {
+            comboboxOptionsContainer.style.display = 'none';
+        }, 200);
+    });
+
+    comboboxInput.addEventListener('input', () => {
+        const filter = comboboxInput.value.toUpperCase();
+        comboboxOptions.forEach(option => {
+            const value = option.textContent || option.innerText;
+            if (value.toUpperCase().indexOf(filter) > -1) {
+                option.style.display = '';
+            } else {
+                option.style.display = 'none';
+            }
+        });
+    });
+
+    comboboxOptions.forEach(option => {
+        option.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            comboboxInput.value = option.dataset.value;
+            comboboxOptionsContainer.style.display = 'none';
+        });
+    });
+
+    // Modal logic
+    const modal = document.getElementById('suggest-material-modal');
+    const modalTitle = document.getElementById('modal-title');
+    const closeModalBtn = document.querySelector('.close-button');
+    const cancelModalBtn = document.getElementById('cancel-btn');
+    const useApuBtn = document.getElementById('use-apu-btn');
+
+    const openModal = (materialName) => {
+        modalTitle.textContent = `Sugerir Nuevo Material: "${materialName}"`;
+        modal.style.display = 'block';
+    };
+
+    const closeModal = () => {
+        modal.style.display = 'none';
+    };
+
+    closeModalBtn.addEventListener('click', closeModal);
+    cancelModalBtn.addEventListener('click', closeModal);
+    window.addEventListener('click', (event) => {
+        if (event.target == modal) {
+            closeModal();
+        }
+    });
+
+    comboboxInput.addEventListener('blur', () => {
+        setTimeout(() => { // Allow mousedown on option to fire first
+            const inputValue = comboboxInput.value.trim();
+            if (inputValue === '') return;
+
+            const existingOptions = Array.from(comboboxOptions).map(opt => opt.dataset.value);
+            if (!existingOptions.includes(inputValue)) {
+                openModal(inputValue);
+            }
+        }, 200);
+    });
+
+    // Estimation simulation logic
+    const resultsOutput = document.getElementById('results-output');
+    const quantityInput = document.getElementById('quantity');
+
+    const simulateEstimation = () => {
+        const quantity = parseFloat(quantityInput.value) || 100; // Default to 100 if empty
+        const material = comboboxInput.value;
+        const apuBase = document.getElementById('apu-base-select').selectedOptions[0].text;
+
+        const estimatedCost = (Math.random() * 50 + 80).toFixed(2); // Random cost between 80-130
+        const total = (quantity * estimatedCost).toFixed(2);
+
+        resultsOutput.innerHTML = `
+            <p><strong>Material:</strong> ${material}</p>
+            <p><strong>APU Base Utilizado:</strong> ${apuBase}</p>
+            <p><strong>Cantidad:</strong> ${quantity} m2</p>
+            <p><strong>Costo Estimado por m2:</strong> $${estimatedCost}</p>
+            <hr>
+            <p><strong>Total Estimado:</strong> $${total}</p>
+        `;
+        closeModal();
+    };
+
+    useApuBtn.addEventListener('click', simulateEstimation);
+    document.getElementById('estimate-btn').addEventListener('click', () => {
+        // Also allow direct estimation if material exists
+        const inputValue = comboboxInput.value.trim();
+        const existingOptions = Array.from(comboboxOptions).map(opt => opt.dataset.value);
+        if (inputValue !== '' && existingOptions.includes(inputValue)) {
+             // A simplified simulation for existing materials
+            const quantity = parseFloat(quantityInput.value) || 100;
+            const estimatedCost = (Math.random() * 40 + 70).toFixed(2); // 70-110
+            const total = (quantity * estimatedCost).toFixed(2);
+            resultsOutput.innerHTML = `
+                <p><strong>Material:</strong> ${inputValue}</p>
+                <p><strong>Cantidad:</strong> ${quantity} m2</p>
+                <p><strong>Costo Estimado por m2:</strong> $${estimatedCost}</p>
+                <hr>
+                <p><strong>Total Estimado:</strong> $${total}</p>
+            `;
+        } else if(inputValue !== '') {
+            openModal(inputValue);
+        }
+    });
+});

--- a/prototipo_v2/style.css
+++ b/prototipo_v2/style.css
@@ -1,0 +1,216 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+
+body {
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    background-color: #f8f9fa;
+    color: #495057;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    background-color: #ffffff;
+    padding: 20px 40px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    border-bottom: 3px solid #0d6efd;
+}
+
+h1 {
+    margin: 0;
+    font-size: 2.2em;
+    color: #343a40;
+    font-weight: 700;
+}
+
+.tabs {
+    display: flex;
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 25px;
+}
+
+.tab-link {
+    padding: 12px 25px;
+    cursor: pointer;
+    border: none;
+    background-color: transparent;
+    font-size: 1.1em;
+    color: #6c757d;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -1px;
+    transition: all 0.2s ease-in-out;
+}
+
+.tab-link:hover {
+    color: #0d6efd;
+}
+
+.tab-link.active {
+    border-bottom-color: #0d6efd;
+    font-weight: 500;
+    color: #0d6efd;
+}
+
+.tab-content {
+    display: none;
+    padding: 25px;
+    background-color: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 0 8px 8px 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.tab-content.active {
+    display: block;
+}
+
+/* Form & Results Styles */
+.estimator-form, .estimation-results {
+    margin-top: 25px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 500;
+    color: #495057;
+}
+
+input[type="text"], input[type="number"], select {
+    width: 100%;
+    padding: 12px 15px;
+    border: 1px solid #ced4da;
+    border-radius: 6px;
+    box-sizing: border-box;
+    transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+input[type="text"]:focus, input[type="number"]:focus, select:focus {
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+button, .button {
+    background-color: #0d6efd;
+    color: white;
+    padding: 12px 20px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+    transition: background-color 0.2s ease-in-out;
+}
+
+button:hover, .button:hover {
+    background-color: #0b5ed7;
+}
+
+.estimation-results {
+    padding: 20px;
+    background-color: #f8f9fa;
+    border-radius: 6px;
+    border: 1px solid #e9ecef;
+}
+
+/* Combobox Styles */
+.combobox-wrapper {
+    position: relative;
+}
+
+.combobox-options {
+    display: none;
+    position: absolute;
+    border: 1px solid #ccc;
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    max-height: 150px;
+    overflow-y: auto;
+    background-color: white;
+    width: 100%;
+    z-index: 1000;
+}
+
+.combobox-option {
+    padding: 10px;
+    cursor: pointer;
+}
+
+.combobox-option:hover, .combobox-option.highlighted {
+    background-color: #f0f0f0;
+}
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1001;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.5);
+    backdrop-filter: blur(5px);
+}
+
+.modal-content {
+    background-color: #ffffff;
+    margin: 10% auto;
+    padding: 30px;
+    border: 1px solid #dee2e6;
+    width: 90%;
+    max-width: 550px;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    animation: fadeIn 0.3s;
+}
+
+@keyframes fadeIn {
+    from {opacity: 0; transform: translateY(-20px);}
+    to {opacity: 1; transform: translateY(0);}
+}
+
+.close-button {
+    color: #6c757d;
+    float: right;
+    font-size: 2.5rem;
+    font-weight: 300;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.close-button:hover,
+.close-button:focus {
+    color: #343a40;
+    text-decoration: none;
+    cursor: pointer;
+    opacity: 1;
+}
+
+.modal-actions {
+    margin-top: 25px;
+    text-align: right;
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.modal-actions .secondary {
+    background-color: #6c757d;
+}
+
+.modal-actions .secondary:hover {
+    background-color: #5a6268;
+}


### PR DESCRIPTION
This commit introduces a fully interactive, high-fidelity web prototype for the APU_filter v2 application. The prototype is built with HTML, CSS, and JavaScript and is located in the `prototipo_v2/` directory.

The prototype includes the three main views as requested:
- Simulador de Costos (placeholder)
- Organizador y Resúmenes (placeholder)
- Estimador Rápido (fully implemented)

The key feature, "Sugerencia de Atributos Dinámicos," is fully functional. When a user enters a new material in the "Estimador Rápido" tab, a modal appears, allowing them to select a base APU for a simulated cost estimation. The results are then displayed on the page.

The visual design has been updated to be modern, clean, and professional for presentation to the client, Estrutechos.