### PR TITLE
feat: Improve estimator logic and fix modal UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -543,7 +543,16 @@
             contentHTML += `
                 <div class="border rounded-lg overflow-hidden">
                     <h4 class="bg-gray-100 px-4 py-2 font-semibold text-gray-700">${catName}</h4>
-                    <table class="min-w-full"><tbody class="divide-y divide-gray-200">
+                    <table class="min-w-full">
+                        <thead class="bg-gray-50 text-xs uppercase text-gray-700">
+                            <tr>
+                                <th class="py-2 px-4 text-left">Descripción</th>
+                                <th class="py-2 px-4 text-right">Cantidad</th>
+                                <th class="py-2 px-4 text-right">Vr. Unitario</th>
+                                <th class="py-2 px-4 text-right">Vr. Total</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
             `;
             category.items.forEach(insumo => {
                 contentHTML += `<tr class="text-sm"><td class="py-2 px-4">${insumo['Descripción']}</td><td class="py-2 px-4 text-right">${(insumo['Cantidad'] || 0).toFixed(3)}</td><td class="py-2 px-4 text-right">${formatCurrency(insumo['Vr Unitario'])}</td><td class="py-2 px-4 text-right">${formatCurrency(insumo['Vr Total'])}</td></tr>`;


### PR DESCRIPTION
This commit addresses two issues:

1.  **Estimator Logic (`procesador_csv.py`):**
    - The `min_score_threshold` in `calculate_estimate` has been lowered from 5 to 3 to allow for more flexible matching of installation APUs.
    - A fallback mechanism has been added to the supply cost estimation. If a direct "supply-only" APU is not found, the system now searches the `insumos.csv` list for the material and uses its unit value. This ensures a supply cost is found if the material exists.

2.  **APU Detail Modal UI (`templates/index.html`):**
    - Added table headers ("Descripción", "Cantidad", "Vr. Unitario", "Vr. Total") to the tables within the APU detail modal. This resolves a UI issue where the data was unclear to the user.