### PR TITLE
feat: Implement APU classification and frontend grouping

### DIFF
--- a/app_output.log
+++ b/app_output.log
@@ -1,0 +1,6 @@
+ * Serving Flask app 'app'
+ * Debug mode: on
+2025-09-15 17:17:42,255 - INFO - [31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on http://127.0.0.1:5002
+2025-09-15 17:17:42,255 - INFO - [33mPress CTRL+C to quit[0m
+2025-09-15 17:17:42,256 - INFO -  * Restarting with stat

--- a/templates/index.html
+++ b/templates/index.html
@@ -389,74 +389,108 @@
         const tableBody = document.getElementById('presupuesto-table-body');
         tableBody.innerHTML = '';
 
-        // Agrupar datos por la nueva clave 'grupo'
-        const groupedData = budgetData.reduce((acc, item) => {
-            const group = item.grupo || 'Ítems Varios';
-            if (!acc[group]) {
-                acc[group] = [];
+        // 1. Calcular el costo total consolidado primero
+        budgetData.forEach(item => {
+            const valorConstruccionAIU = (item.VALOR_CONSTRUCCION_UN || 0) * aiuFactor;
+            totalConsolidado += valorConstruccionAIU * (item.CANTIDAD_PRESUPUESTO || 0);
+        });
+        document.getElementById('total-cost').textContent = formatCurrency(totalConsolidado);
+
+        // 2. Agrupación Primaria: por tipo_apu
+        const apuTypeGroups = budgetData.reduce((acc, item) => {
+            const type = item.tipo_apu || 'Indefinido';
+            if (!acc[type]) {
+                acc[type] = { items: [], subtotal: 0 };
             }
-            acc[group].push(item);
+            acc[type].items.push(item);
+            const itemCost = (item.VALOR_CONSTRUCCION_UN || 0) * (item.CANTIDAD_PRESUPUESTO || 0) * aiuFactor;
+            acc[type].subtotal += itemCost;
             return acc;
         }, {});
 
-        // Ordenar los grupos, poniendo "Ítems Varios" al final
-        const sortedGroups = Object.keys(groupedData).sort((a, b) => {
-            if (a === 'Ítems Varios') return 1;
-            if (b === 'Ítems Varios') return -1;
-            return a.localeCompare(b);
+        // Ordenar los tipos de APU
+        const sortedApuTypes = Object.keys(apuTypeGroups).sort((a, b) => {
+            const order = { 'Suministro': 1, 'Instalación': 2, 'Obra Completa': 3, 'Indefinido': 4 };
+            return (order[a] || 99) - (order[b] || 99);
         });
 
-        for (const groupName of sortedGroups) {
-            const items = groupedData[groupName];
-            const groupId = `group-${groupName.replace(/[^a-zA-Z0-9]/g, '-')}`;
+        // 3. Renderizar la jerarquía de tres niveles
+        for (const apuType of sortedApuTypes) {
+            const apuGroupData = apuTypeGroups[apuType];
+            const typeId = `type-${apuType.replace(/[^a-zA-Z0-9]/g, '-')}`;
 
-            // Crear la fila de cabecera del grupo
-            const groupHeaderRow = document.createElement('tr');
-            groupHeaderRow.className = 'bg-blue-100 hover:bg-blue-200 cursor-pointer';
-            groupHeaderRow.onclick = () => {
-                document.querySelectorAll(`.${groupId}-item`).forEach(row => {
-                    row.classList.toggle('hidden');
-                });
-            };
-            groupHeaderRow.innerHTML = `
-                <td colspan="2" class="px-4 py-3 text-sm font-bold text-blue-800">
-                    ${groupName} (${items.length} ítems)
+            // Nivel 1: Cabecera del Tipo de APU (Suministro, Instalación, etc.)
+            const typeHeaderRow = document.createElement('tr');
+            typeHeaderRow.className = 'bg-gray-200 hover:bg-gray-300 cursor-pointer';
+            typeHeaderRow.onclick = () => document.querySelectorAll(`.${typeId}-child`).forEach(el => el.classList.toggle('hidden'));
+            typeHeaderRow.innerHTML = `
+                <td colspan="5" class="px-4 py-3 text-base font-bold text-gray-800 uppercase">
+                    ▶ ${apuType}
                 </td>
-                <td colspan="4"></td>
+                <td class="px-4 py-3 text-base font-bold text-gray-800 text-right">
+                    ${formatCurrency(apuGroupData.subtotal)}
+                </td>
             `;
-            tableBody.appendChild(groupHeaderRow);
+            tableBody.appendChild(typeHeaderRow);
 
-            // Crear las filas de ítems para este grupo
-            items.forEach(item => {
-                const valorSuministroAIU = (item.VALOR_SUMINISTRO_UN || 0) * aiuFactor;
-                const valorInstalacionAIU = (item.VALOR_INSTALACION_UN || 0) * aiuFactor;
-                const valorConstruccionAIU = (item.VALOR_CONSTRUCCION_UN || 0) * aiuFactor;
-                totalConsolidado += valorConstruccionAIU * (item.CANTIDAD_PRESUPUESTO || 0);
+            // Agrupación Secundaria: por 'grupo' (descripción) dentro de cada tipo de APU
+            const descriptionGroups = apuGroupData.items.reduce((acc, item) => {
+                const group = item.grupo || 'Ítems Varios';
+                if (!acc[group]) {
+                    acc[group] = [];
+                }
+                acc[group].push(item);
+                return acc;
+            }, {});
 
-                const tiempoInstalacion = item.TIEMPO_INSTALACION;
-                const tiempoFormateado = (tiempoInstalacion !== null && !isNaN(tiempoInstalacion))
-                    ? `${parseFloat(tiempoInstalacion).toFixed(4)} Días/Un.`
-                    : 'N/A';
+            const sortedDescriptionGroups = Object.keys(descriptionGroups).sort((a, b) => a.localeCompare(b));
 
-                const itemRow = document.createElement('tr');
-                itemRow.className = `hidden ${groupId}-item hover:bg-gray-50 cursor-pointer`;
-                itemRow.onclick = (e) => {
+            for (const groupName of sortedDescriptionGroups) {
+                const items = descriptionGroups[groupName];
+                const groupId = `group-${groupName.replace(/[^a-zA-Z0-9]/g, '-')}`;
+
+                // Nivel 2: Cabecera de la Descripción (REMATE CON PINTURA, etc.)
+                const groupHeaderRow = document.createElement('tr');
+                groupHeaderRow.className = `hidden ${typeId}-child bg-blue-100 hover:bg-blue-200 cursor-pointer`;
+                groupHeaderRow.onclick = (e) => {
                     e.stopPropagation();
-                    openModal(item.CODIGO_APU);
+                    document.querySelectorAll(`.${groupId}-item`).forEach(row => row.classList.toggle('hidden'));
                 };
-                itemRow.innerHTML = `
-                    <td class="px-4 py-4 text-sm font-medium text-gray-900">${item.CODIGO_APU}</td>
-                    <td class="px-4 py-4 text-sm text-gray-500">${item.DESCRIPCION_APU}</td>
-                    <td class="px-4 py-4 text-sm text-gray-500">${formatCurrency(valorSuministroAIU)}</td>
-                    <td class="px-4 py-4 text-sm text-gray-500">${formatCurrency(valorInstalacionAIU)}</td>
-                    <td class="px-4 py-4 text-sm font-semibold text-gray-700">${formatCurrency(valorConstruccionAIU)}</td>
-                    <td class="px-4 py-4 text-sm text-gray-500">${tiempoFormateado}</td>
+                groupHeaderRow.innerHTML = `
+                    <td class="pl-8 pr-4 py-3 text-sm font-bold text-blue-800" colspan="5">
+                        ▶ ${groupName} (${items.length} ítems)
+                    </td>
+                    <td colspan="1"></td>
                 `;
-                tableBody.appendChild(itemRow);
-            });
-        }
+                tableBody.appendChild(groupHeaderRow);
 
-        document.getElementById('total-cost').textContent = formatCurrency(totalConsolidado);
+                // Nivel 3: Filas de Ítems
+                items.forEach(item => {
+                    const valorSuministroAIU = (item.VALOR_SUMINISTRO_UN || 0) * aiuFactor;
+                    const valorInstalacionAIU = (item.VALOR_INSTALACION_UN || 0) * aiuFactor;
+                    const valorConstruccionAIU = (item.VALOR_CONSTRUCCION_UN || 0) * aiuFactor;
+                    const tiempoFormateado = (item.TIEMPO_INSTALACION !== null && !isNaN(item.TIEMPO_INSTALACION))
+                        ? `${parseFloat(item.TIEMPO_INSTALACION).toFixed(4)} Días/Un.`
+                        : 'N/A';
+
+                    const itemRow = document.createElement('tr');
+                    itemRow.className = `hidden ${typeId}-child ${groupId}-item hover:bg-gray-50 cursor-pointer`;
+                    itemRow.onclick = (e) => {
+                        e.stopPropagation();
+                        openModal(item.CODIGO_APU);
+                    };
+                    itemRow.innerHTML = `
+                        <td class="pl-12 pr-4 py-4 text-sm font-medium text-gray-900">${item.CODIGO_APU}</td>
+                        <td class="px-4 py-4 text-sm text-gray-500">${item.DESCRIPCION_APU}</td>
+                        <td class="px-4 py-4 text-sm text-gray-500">${formatCurrency(valorSuministroAIU)}</td>
+                        <td class="px-4 py-4 text-sm text-gray-500">${formatCurrency(valorInstalacionAIU)}</td>
+                        <td class="px-4 py-4 text-sm font-semibold text-gray-700">${formatCurrency(valorConstruccionAIU)}</td>
+                        <td class="px-4 py-4 text-sm text-gray-500">${tiempoFormateado}</td>
+                    `;
+                    tableBody.appendChild(itemRow);
+                });
+            }
+        }
     }
 
     function updateOrganizerTable() {


### PR DESCRIPTION
Refactors the application to align with standard construction industry APU (Análisis de Precios Unitarios) methodology.

Backend (`procesador_csv.py`):
- Adds a `classify_apu` function to categorize APUs into "Suministro", "Instalación", or "Obra Completa" based on the proportion of material vs. labor/equipment costs.
- Integrates this classification into the main data processing pipeline, adding a `tipo_apu` field to each budget item.

Frontend (`templates/index.html`):
- Reworks the 'Simulador de Costos' view entirely.
- Removes the old grouping and implements a new three-level hierarchical accordion structure.
- The new hierarchy is: APU Type -> Item Description -> Individual Item.
- The main APU Type accordions now display a subtotal for their respective categories.

This change provides users with a more intuitive and industry-standard view of their project budget, allowing for a clearer distinction between material, installation, and complete work costs.