### PR TITLE
feat: Add tests for probability_models and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ APU Filter es una plataforma de inteligencia de negocio diseñada para el sector
 - **Optimización a la Vista:** Identifique rápidamente oportunidades de optimización y tome decisiones informadas para mejorar el margen de sus proyectos.
 
 ## Características Principales
+- **Motor de Simulación de Riesgos (Monte Carlo):** Va más allá de los cálculos estáticos. APU_filter simula miles de posibles resultados para cada APU, modelando la volatilidad de los precios de materiales y la variabilidad en el rendimiento de la mano de obra. Obtén el costo esperado, la desviación estándar y rangos de confianza para entender el verdadero perfil de riesgo de tu presupuesto.
 - **Carga de Reportes SAGUT:** Procesamiento automatizado de archivos de Presupuesto, APU e Insumos.
 - **Simulador AIU:** Módulo interactivo para modelar el impacto de los costos indirectos.
 - **Organizador de Proyecto:** Visualización y análisis detallado de la estructura de costos.
@@ -80,23 +81,22 @@ Siga estos pasos para configurar el entorno de desarrollo y poner en marcha la a
 ```
 apu_filter/
 │
-├── .venv/                   # Carpeta del entorno virtual gestionado por uv
+├── app/                     # Contiene la lógica de la aplicación Flask
+│   ├── __init__.py
+│   ├── app.py               # El servidor Flask y los endpoints
+│   └── procesador_csv.py    # Lógica de parsing y procesamiento de datos
 │
-├── templates/               # Archivos HTML para la interfaz
-│   └── index.html           # Dashboard interactivo de una sola página
+├── models/                  # Módulos de lógica de negocio y análisis
+│   ├── __init__.py
+│   └── probability_models.py# Motor de simulación Monte Carlo
 │
-├── uploads/                 # Carpeta temporal para los archivos subidos
+├── tests/                   # Pruebas unitarias y de integración
+│   ├── __init__.py
+│   ├── test_processing.py   # Pruebas para procesador_csv.py
+│   └── test_models.py       # Pruebas para probability_models.py
 │
-├── app.py                   # Servidor Flask y lógica de la aplicación
-├── procesador_csv.py        # Módulo para leer y procesar los reportes de SAGUT
-├── test_app.py              # Pruebas unitarias
-│
-├── pyproject.toml           # Archivo de configuración del proyecto (incluye Ruff)
-├── README.md                # Documentación del proyecto
-│
-├── requirements.in          # Dependencias base
-├── requirements.txt         # Dependencias de producción (compilado)
-│
-├── requirements-dev.in      # Dependencias de desarrollo
-└── requirements-dev.txt     # Dependencias de desarrollo (compilado)
+├── templates/
+├── uploads/
+├── config.json              # Archivo de configuración
+└── ...
 ```

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,71 @@
+import unittest
+import os
+import sys
+
+# Add project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from models.probability_models import run_monte_carlo_simulation
+
+class TestProbabilityModels(unittest.TestCase):
+
+    def test_simulation_returns_correct_structure(self):
+        """
+        Verifies that the simulation result has the correct structure.
+        """
+        apu_details = [
+            {"CATEGORIA": "MATERIALES", "VALOR_UNITARIO": 100, "CANTIDAD": 10},
+            {"CATEGORIA": "MANO DE OBRA", "VALOR_UNITARIO": 50, "CANTIDAD": 5},
+        ]
+        result = run_monte_carlo_simulation(apu_details, num_simulations=10)
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("mean", result)
+        self.assertIn("std_dev", result)
+        self.assertIn("percentile_5", result)
+        self.assertIn("percentile_95", result)
+
+    def test_simulation_values_are_reasonable(self):
+        """
+        Verifies that the simulation values are reasonable for a known input.
+        """
+        # Con un costo determinista de $1000 (100*10) y sin variaciones aleatorias
+        # para la categoría 'OTROS', el resultado debe ser muy cercano a 1000.
+        apu_details = [
+            {"CATEGORIA": "OTROS", "VALOR_UNITARIO": 100, "CANTIDAD": 10},
+        ]
+
+        # Usamos un número alto de simulaciones para que la media se acerque al valor real
+        result = run_monte_carlo_simulation(apu_details, num_simulations=10000)
+
+        # El costo esperado (mean) debe ser muy cercano al costo determinista
+        self.assertAlmostEqual(result['mean'], 1000, delta=1) # Delta muy pequeño porque no hay aleatoriedad
+
+        # Con un apu_details que sí tiene componentes aleatorios
+        apu_details_random = [
+            {"CATEGORIA": "MATERIALES", "VALOR_UNITARIO": 80, "CANTIDAD": 10}, # 800
+            {"CATEGORIA": "MANO DE OBRA", "VALOR_UNITARIO": 20, "CANTIDAD": 10}, # 200
+        ]
+
+        result_random = run_monte_carlo_simulation(apu_details_random, num_simulations=1000)
+
+        # El costo esperado debe estar cerca de 1000, pero con más margen por la aleatoriedad
+        self.assertAlmostEqual(result_random['mean'], 1000, delta=100)
+
+        # Los percentiles deben tener sentido
+        self.assertLess(result_random['percentile_5'], result_random['mean'])
+        self.assertGreater(result_random['percentile_95'], result_random['mean'])
+        self.assertGreater(result_random['std_dev'], 0)
+
+
+    def test_simulation_handles_empty_input(self):
+        """
+        Verifies that the simulation handles empty input gracefully.
+        """
+        apu_details = []
+        result = run_monte_carlo_simulation(apu_details, num_simulations=10)
+
+        self.assertEqual(result["mean"], 0)
+        self.assertEqual(result["std_dev"], 0)
+        self.assertEqual(result["percentile_5"], 0)
+        self.assertEqual(result["percentile_95"], 0)


### PR DESCRIPTION
Adds unit tests for the `run_monte_carlo_simulation` function in `models/probability_models.py`. The tests cover the output structure, the reasonableness of the simulation values, and the handling of empty inputs.

Updates the `README.md` to reflect the current state of the project, including the new risk simulation functionality and the modular project structure.