### PR TITLE
Fix(parser): Clean trailing characters from APU codes

### DIFF
--- a/app/procesador_csv.py
+++ b/app/procesador_csv.py
@@ -379,7 +379,10 @@ def process_apus_csv_v2(path: str) -> pd.DataFrame:
                 if "ITEM:" in line.upper():
                     match = re.search(r"ITEM:\s*([\d,\.]*)", line.upper())
                     if match and match.group(1).strip():
-                        current_context["apu_code"] = match.group(1).strip()
+                        apu_code = match.group(1).strip()
+                        # Limpiar puntos o comas extra al final del código
+                        apu_code = apu_code.rstrip('.,')
+                        current_context["apu_code"] = apu_code
                         current_context["apu_desc"] = potential_apu_desc
                         current_context["category"] = "INDEFINIDO"
                         potential_apu_desc = ""  # Reiniciar


### PR DESCRIPTION
This commit addresses an issue where APU codes with trailing dots or commas were not being parsed correctly. The `process_apus_csv_v2` function in `app/procesador_csv.py` has been updated to strip these characters from the end of the `apu_code` string after extraction.

This change ensures that malformed APU codes like '1.1.' or '1.1,' are correctly identified as '1.1', making the parsing logic more robust and resolving the failing test case `test_process_apus_with_malformed_code`.