### PR TITLE
Test: Add tests for fuzzywuzzy integration

### DIFF
--- a/app/procesador_csv.py
+++ b/app/procesador_csv.py
@@ -739,9 +739,15 @@ def calculate_estimate(
 
     # --- 1. Búsqueda de Suministro (Refactorizada con Fuzzy-Matching) ---
     log.append("\n--- BÚSQUEDA DE SUMINISTRO ---")
-    opciones_suministro = df_apus_unique["DESC_NORMALIZED"].tolist()
+
+    # Filtrar primero por APUs que parezcan de suministro
+    df_suministro_options = df_apus_unique[
+        df_apus_unique["DESC_NORMALIZED"].str.contains("SUMINISTRO|SOLO", na=False)
+    ]
+    opciones_suministro = df_suministro_options["DESC_NORMALIZED"].tolist()
+
     log.append(
-        f"Buscando la mejor coincidencia para '{material_mapped}' en {len(opciones_suministro)} opciones."
+        f"Buscando la mejor coincidencia para '{material_mapped}' en {len(opciones_suministro)} opciones de suministro."
     )
     mejor_coincidencia = encontrar_mejor_coincidencia(material_mapped, opciones_suministro)
 


### PR DESCRIPTION
This commit adds tests for the new fuzzywuzzy-based search logic in `procesador_csv.py`.

- Adds a test case (`test_calculate_estimate_with_fuzzywuzzy`) that mocks the `fuzzywuzzy` library to verify the estimation logic in a controlled environment.
- Adds a resilience test (`test_calculate_estimate_resilience_without_fuzzywuzzy`) to ensure that the application raises an `ImportError` if the `fuzzywuzzy` dependency is not found.
- Refactors the fuzzy search logic slightly to be more specific and avoid incorrect matches, which was discovered during testing.