### PR TITLE
Fix(parser): Flexibiliza las regex para el parseo de reportes

### DIFF
--- a/app/report_parser.py
+++ b/app/report_parser.py
@@ -18,27 +18,26 @@ class ReportParser:
         "item_code": re.compile(r"ITEM:\s*([\d\s,.]*)$"),
         "category": re.compile(r"^(MATERIALES|MANO DE OBRA|EQUIPO|OTROS)$"),
         "mano_de_obra_compleja": re.compile(
-            r"^(?P<descripcion>.+?)\s{2,}"
-            r"(?P<jornal_base>[\d.,]+)\s{2,}"
-            r"(?P<prestaciones>[\d.,]+)\s{2,}"
-            r"(?P<jornal_total>[\d.,]+)\s{2,}"
-            r"(?P<rendimiento>[\d.,]+)\s{2,}"
+            r"^(?P<descripcion>.+?)\s+"
+            r"(?P<jornal_base>[\d.,]+)\s+"
+            r"(?P<prestaciones>\S+)\s+"  # Puede ser % o número
+            r"(?P<jornal_total>[\d.,]+)\s+"
+            r"(?P<rendimiento>[\d.,]+)\s+"
             r"(?P<valor_total>[\d.,]+)$"
         ),
-        # Se incluye el dígito en la unidad para casos como 'M2'.
         "insumo_full": re.compile(
-            r"^(?P<descripcion>.+?)\s{2,}"
-            r"(?P<unidad>[A-Z0-9%]{2,10})\s{2,}"
-            r"(?P<cantidad>[\d.,]+)\s{2,}"
-            r"(?P<desperdicio>\S+)\s{2,}"
-            r"(?P<precio_unit>[\d\s.,]+?)\s{2,}"
+            r"^(?P<descripcion>.+?)\s+"
+            r"(?P<unidad>[A-Z0-9%]{2,10})\s+"
+            r"(?P<cantidad>[\d.,]+)\s+"
+            r"(?P<desperdicio>\S+)\s+"
+            r"(?P<precio_unit>[\d\s.,]+?)\s+"
             r"(?P<valor_total>[\d\s.,]+)$"
         ),
         "insumo_simple": re.compile(
-            r"^(?P<descripcion>.+?)\s{2,}"
-            r"(?P<unidad>[A-Z0-9%]{2,10})\s{2,}"
-            r"(?P<cantidad>[\d.,]+)\s{2,}"
-            r"(?P<precio_unit>[\d\s.,]+?)\s{2,}"
+            r"^(?P<descripcion>.+?)\s+"
+            r"(?P<unidad>[A-Z0-9%]{2,10})\s+"
+            r"(?P<cantidad>[\d.,]+)\s+"
+            r"(?P<precio_unit>[\d\s.,]+?)\s+"
             r"(?P<valor_total>[\d\s.,]+)$"
         ),
         "herramienta_menor": re.compile(


### PR DESCRIPTION
Se actualizan las expresiones regulares en `app/report_parser.py` para mejorar la robustez del parseo de archivos de APU.

Los cambios clave son:
- Se reemplaza el separador estricto `\s{2,}` por `\s+`, permitiendo uno o más espacios entre columnas. Esto maneja variaciones de espaciado en los archivos de producción.
- Se ajusta la regex `mano_de_obra_compleja` para que el campo `prestaciones` pueda capturar tanto valores numéricos como porcentajes (`\S+`).
- La estructura de las regex ahora prioriza la captura de campos numéricos desde el final de la línea, haciendo que la captura de la descripción sea más fiable.

Este cambio soluciona un bug donde el `ReportParser` devolvía un DataFrame vacío al no poder encontrar coincidencias en el archivo `apus.csv` de producción.