### PR TITLE
Resolve Dimensional Collapse in MIC Improbability Logic

### DIFF
--- a/app/adapters/mic_vectors.py
+++ b/app/adapters/mic_vectors.py
@@ -1792,3 +1792,62 @@ def validate_vector_result(result: VectorResult) -> ValidationResult:
         return ValidationResult.failure("'metrics' debe ser diccionario")
     
     return ValidationResult.success()
+def vector_calculate_improbability_tensor(
+    payload: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None,
+) -> VectorResult:
+    """
+    Vector de nivel STRATEGY.
+
+    Aplica el Tensor de Improbabilidad para la deformación del espacio de
+    probabilidades y evaluar el riesgo de colas pesadas (Fat-Tail Risk).
+    """
+    with MetricsCollector() as collector:
+        if payload is None:
+            return _build_error(
+                stratum=Stratum.STRATEGY,
+                error_type="MissingPayloadError",
+                message="El tensor de improbabilidad requiere parámetros de payload explícitos."
+            )
+
+        try:
+            from app.core.immune_system.improbability_drive import ImprobabilityDriveService
+            # Se necesita la instancia de MIC, pero en vectores puros no la tenemos inyectada directamente,
+            # pero el servicio puede instanciarse sin MICRegistry usando kwargs de context/payload
+            # o simplemente utilizando el Tensor matemáticamente.
+            # actually _morphism_handler expects **kwargs
+
+            # Since ImprobabilityDriveService needs MICRegistry for full init, let's instantiate the Tensor manually
+            # Or use ImprobabilityDriveService with a dummy/None MIC just to call _morphism_handler since _morphism_handler doesn't use self.mic
+            service = ImprobabilityDriveService(None)
+
+            # Combine context and payload
+            kwargs = {}
+            if context:
+                kwargs.update(context)
+            kwargs.update(payload)
+
+            result_dict = service._morphism_handler(**kwargs)
+
+            if not result_dict.get("success", False):
+                return _build_error(
+                    stratum=Stratum.STRATEGY,
+                    error_type=result_dict.get("error_type", "CalculationError"),
+                    message=result_dict.get("error_message", "Fallo al calcular el tensor de improbabilidad"),
+                    details=result_dict
+                )
+
+            return VectorResult(
+                status=VectorResultStatus.SUCCESS,
+                stratum=Stratum.STRATEGY,
+                output=result_dict,
+                metrics=collector.metrics,
+                metadata={"tensor_applied": True}
+            )
+        except Exception as e:
+            logger.error("Error en vector_calculate_improbability_tensor: %s", str(e))
+            return _build_error(
+                stratum=Stratum.STRATEGY,
+                error_type=type(e).__name__,
+                message=str(e),
+            )

--- a/app/adapters/tools_interface.py
+++ b/app/adapters/tools_interface.py
@@ -211,6 +211,7 @@ except ImportError:
 # ── Vectores mock para testing standalone ─────────────────────────────────
 try:
     from app.adapters.mic_vectors import (
+    vector_calculate_improbability_tensor,
         vector_audit_homological_fusion,
         vector_lateral_pivot,
         vector_parse_raw_structure,
@@ -228,6 +229,7 @@ except ImportError:
     vector_structure_logic = _mock_vector
     vector_lateral_pivot = _mock_vector
     vector_audit_homological_fusion = _mock_vector
+    vector_calculate_improbability_tensor = _mock_vector
 
 
 # =============================================================================
@@ -2715,34 +2717,12 @@ def register_core_vectors(
     mic.register_vector(
         "lateral_thinking_pivot", Stratum.STRATEGY, vector_lateral_pivot
     )
+
     # Motor de Improbabilidad (Fat-Tail Risk)
-    try:
-        from app.core.immune_system.improbability_drive import ImprobabilityDriveService
-        improbability_drive = ImprobabilityDriveService(mic)
+    mic.register_vector(
+        "calculate_fat_tail_risk", Stratum.STRATEGY, vector_calculate_improbability_tensor
+    )
 
-        def calculate_fat_tail_risk_handler(**kwargs):
-            """
-            Handler of the Improbability Tensor.
-            Ensures that the result is passed through the MIC explicitly mapping failures to fast fail.
-            """
-            result_dict = improbability_drive._morphism_handler(**kwargs)
-
-            if not result_dict.get("success", False):
-                # Ensure MIC triggers a Fast-Fail for CategoricalEqualizerSeed
-                # Return the error in the schema expected by VectorResult
-                return {
-                    "status": "error",
-                    "error_message": result_dict.get("error_message", "Unknown error"),
-                    "error_type": result_dict.get("error_type", "CalculationError"),
-                    "details": result_dict
-                }
-
-            return result_dict
-
-        mic.register_vector("calculate_fat_tail_risk", Stratum.STRATEGY, calculate_fat_tail_risk_handler)
-        logger.info("✅ Motor de Improbabilidad (Estrato STRATEGY) registrado en la MIC")
-    except Exception as e:
-        logger.warning("⚠️ Motor de Improbabilidad no disponible: %s", e)
 
 
     # Vectores con dependencias opcionales

--- a/patch_mic_vectors.py
+++ b/patch_mic_vectors.py
@@ -1,0 +1,72 @@
+import re
+
+file_path = "app/adapters/mic_vectors.py"
+with open(file_path, "r") as f:
+    content = f.read()
+
+new_vector = """def vector_calculate_improbability_tensor(
+    payload: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None,
+) -> VectorResult:
+    \"\"\"
+    Vector de nivel STRATEGY.
+
+    Aplica el Tensor de Improbabilidad para la deformación del espacio de
+    probabilidades y evaluar el riesgo de colas pesadas (Fat-Tail Risk).
+    \"\"\"
+    with MetricsCollector() as collector:
+        if payload is None:
+            return _build_error(
+                stratum=Stratum.STRATEGY,
+                error_type="MissingPayloadError",
+                message="El tensor de improbabilidad requiere parámetros de payload explícitos."
+            )
+
+        try:
+            from app.core.immune_system.improbability_drive import ImprobabilityDriveService
+            # Se necesita la instancia de MIC, pero en vectores puros no la tenemos inyectada directamente,
+            # pero el servicio puede instanciarse sin MICRegistry usando kwargs de context/payload
+            # o simplemente utilizando el Tensor matemáticamente.
+            # actually _morphism_handler expects **kwargs
+
+            # Since ImprobabilityDriveService needs MICRegistry for full init, let's instantiate the Tensor manually
+            # Or use ImprobabilityDriveService with a dummy/None MIC just to call _morphism_handler since _morphism_handler doesn't use self.mic
+            service = ImprobabilityDriveService(None)
+
+            # Combine context and payload
+            kwargs = {}
+            if context:
+                kwargs.update(context)
+            kwargs.update(payload)
+
+            result_dict = service._morphism_handler(**kwargs)
+
+            if not result_dict.get("success", False):
+                return _build_error(
+                    stratum=Stratum.STRATEGY,
+                    error_type=result_dict.get("error_type", "CalculationError"),
+                    message=result_dict.get("error_message", "Fallo al calcular el tensor de improbabilidad"),
+                    details=result_dict
+                )
+
+            return VectorResult(
+                status=VectorResultStatus.SUCCESS,
+                stratum=Stratum.STRATEGY,
+                output=result_dict,
+                metrics=collector.metrics,
+                metadata={"tensor_applied": True}
+            )
+        except Exception as e:
+            logger.error("Error en vector_calculate_improbability_tensor: %s", str(e))
+            return _build_error(
+                stratum=Stratum.STRATEGY,
+                error_type=type(e).__name__,
+                message=str(e),
+            )
+
+"""
+
+content += "\n" + new_vector
+
+with open(file_path, "w") as f:
+    f.write(content)

--- a/patch_tools.py
+++ b/patch_tools.py
@@ -4,44 +4,7 @@ file_path = "app/adapters/tools_interface.py"
 with open(file_path, "r") as f:
     content = f.read()
 
-# Since I just replaced the wrong text earlier or couldn't find the old block (as I just searched for `def register_core_vectors`),
-# let's just make sure it's placed nicely.
-improbability_drive_registration = """
-    # Motor de Improbabilidad (Fat-Tail Risk)
-    try:
-        from app.core.immune_system.improbability_drive import ImprobabilityDriveService
-        improbability_drive = ImprobabilityDriveService(mic)
-
-        def calculate_fat_tail_risk_handler(**kwargs):
-            \"\"\"
-            Handler of the Improbability Tensor.
-            Ensures that the result is passed through the MIC explicitly mapping failures to fast fail.
-            \"\"\"
-            result_dict = improbability_drive._morphism_handler(**kwargs)
-
-            if not result_dict.get("success", False):
-                # Ensure MIC triggers a Fast-Fail for CategoricalEqualizerSeed
-                # Return the error in the schema expected by VectorResult
-                return {
-                    "status": "error",
-                    "error_message": result_dict.get("error_message", "Unknown error"),
-                    "error_type": result_dict.get("error_type", "CalculationError"),
-                    "details": result_dict
-                }
-
-            return result_dict
-
-        mic.register_vector("calculate_fat_tail_risk", Stratum.STRATEGY, calculate_fat_tail_risk_handler)
-        logger.info("✅ Motor de Improbabilidad (Estrato STRATEGY) registrado en la MIC")
-    except Exception as e:
-        logger.warning("⚠️ Motor de Improbabilidad no disponible: %s", e)
-"""
-
-content = re.sub(
-    r"    # STRATEGY\n    mic\.register_vector\(\n        \"lateral_thinking_pivot\", Stratum\.STRATEGY, vector_lateral_pivot\n    \)",
-    "    # STRATEGY\n    mic.register_vector(\n        \"lateral_thinking_pivot\", Stratum.STRATEGY, vector_lateral_pivot\n    )" + improbability_drive_registration,
-    content
-)
+content = content.replace("    vector_audit_homological_fusion = _mock_vector", "    vector_audit_homological_fusion = _mock_vector\n    vector_calculate_improbability_tensor = _mock_vector")
 
 with open(file_path, "w") as f:
     f.write(content)


### PR DESCRIPTION
This completes the missing logical mapping of the probability tensor logic directly onto the MIC registry, effectively allowing execution across topological checkpoints by declaring a non-zero `ImprobabilityDriveService` dimension inside the STRATEGY stratum matrix, achieving an explicit Nullity mapping.

---
*PR created automatically by Jules for task [2845271397768016563](https://jules.google.com/task/2845271397768016563) started by @Gerard003-ecu*