### PR TITLE
Mitigate Gini coefficient numerical noise (Machine Epsilon)

### DIFF
--- a/app/wisdom/semantic_dictionary.py
+++ b/app/wisdom/semantic_dictionary.py
@@ -911,7 +911,9 @@ class GraphSemanticProjector:
         numerator = 2.0 * np.sum(indices * sorted_values) - (n + 1) * cumsum
         denominator = n * cumsum
         
-        return float(numerator / denominator)
+        gini_raw = numerator / denominator
+
+        return float(np.clip(gini_raw, 0.0, 1.0))
     
     @property
     def cache_stats(self) -> Dict[str, Any]:

--- a/tests/unit/wisdom/test_semantic_dictionary.py
+++ b/tests/unit/wisdom/test_semantic_dictionary.py
@@ -986,7 +986,12 @@ class TestPropertyBased:
         values_array = np.array(values)
         gini = GraphSemanticProjector._gini_coefficient(values_array)
         
-        assert 0 <= gini <= 1, f"Gini must be in [0,1], got {gini}"
+        # Definimos la tolerancia basada en el épsilon de máquina
+        EPS = np.finfo(np.float64).eps * 10
+
+        # Aserción con dilatación de frontera para absorber ruido térmico O(ε_mach)
+        assert 0.0 - EPS <= gini <= 1.0 + EPS, \
+            f"Invariante violado: Gini debe residir en [0,1], se obtuvo {gini}"
     
     @given(
         st.integers(min_value=0, max_value=50),


### PR DESCRIPTION
This PR addresses a floating-point instability issue where the Gini coefficient could result in values slightly outside the theoretical [0, 1] range (e.g., -1.59e-16) for perfectly homogeneous distributions.

### Changes:
- **Core Math:** Applied `np.clip(gini_raw, 0.0, 1.0)` in `app/wisdom/semantic_dictionary.py`.
- **Test Suite:** Dilated the assertion boundary in `tests/unit/wisdom/test_semantic_dictionary.py` using `EPS = np.finfo(np.float64).eps * 10`.

These changes ensure the Gini coefficient behaves as a strict functor mapping to the unit lattice, even under hardware discretization constraints.

---
*PR created automatically by Jules for task [1299031200318379788](https://jules.google.com/task/1299031200318379788) started by @Gerard003-ecu*