### PR TITLE
Restore Test Rigor and Topological Invariants

### DIFF
--- a/app/adapters/mic_vectors.py
+++ b/app/adapters/mic_vectors.py
@@ -1241,13 +1241,45 @@ def vector_lateral_pivot(
                 metrics=collector.build_metrics()
             )
 
-        # ─── Extracción de subespacios ───
-        report_state = payload.get("report_state", {})
-        thermal_metrics = payload.get("thermal_metrics", {})
-        financial_metrics = payload.get("financial_metrics", {})
+        # ─── Extracción y Validación de subespacios (Prevención de Entropía) ───
+        report_state = payload.get("report_state")
+        thermal_metrics = payload.get("thermal_metrics")
+        financial_metrics = payload.get("financial_metrics")
         synergy_risk = payload.get("synergy_risk", {})
         
         pivot_type = PivotType.from_string(str(payload.get("pivot_type", "UNKNOWN")))
+
+        # Validación de homogeneidad algebraica de los subespacios inyectados
+        # Solo requerimos diccionarios si el pivot_type no es UNKNOWN
+        if pivot_type != PivotType.UNKNOWN:
+            if not isinstance(report_state, dict):
+                return _build_error(
+                    stratum=Stratum.STRATEGY,
+                    status=VectorResultStatus.VALIDATION_ERROR,
+                    error=f"Morfismo inválido: 'report_state' debe ser dict, obtenido {type(report_state).__name__}",
+                    metrics=collector.build_metrics()
+                )
+
+            if pivot_type == PivotType.MONOPOLIO_COBERTURADO and not isinstance(thermal_metrics, dict):
+                return _build_error(
+                    stratum=Stratum.STRATEGY,
+                    status=VectorResultStatus.VALIDATION_ERROR,
+                    error=f"Morfismo inválido: 'thermal_metrics' debe ser dict, obtenido {type(thermal_metrics).__name__}",
+                    metrics=collector.build_metrics()
+                )
+
+            if pivot_type == PivotType.OPCION_ESPERA and not isinstance(financial_metrics, dict):
+                return _build_error(
+                    stratum=Stratum.STRATEGY,
+                    status=VectorResultStatus.VALIDATION_ERROR,
+                    error=f"Morfismo inválido: 'financial_metrics' debe ser dict, obtenido {type(financial_metrics).__name__}",
+                    metrics=collector.build_metrics()
+                )
+
+        # Defaults para evitar KeyErrors
+        report_state = report_state or {}
+        thermal_metrics = thermal_metrics or {}
+        financial_metrics = financial_metrics or {}
         
         # Variables de estado
         stability = float(report_state.get("stability", PhysicsConstants.DEFAULT_STABILITY))

--- a/app/physics/laplace_oracle.py
+++ b/app/physics/laplace_oracle.py
@@ -581,20 +581,20 @@ class SensitivityMatrix:
     def to_dict(self) -> Dict[str, Any]:
         """Serializa a diccionario."""
         return {
-            "omega_n": {
-                "R": self.S_R_omega_n,
-                "L": self.S_L_omega_n, 
-                "C": self.S_C_omega_n
+            "natural_frequency": {
+                "resistance": self.S_R_omega_n,
+                "inductance": self.S_L_omega_n,
+                "capacitance": self.S_C_omega_n
             },
-            "zeta": {
-                "R": self.S_R_zeta,
-                "L": self.S_L_zeta,
-                "C": self.S_C_zeta
+            "damping_ratio": {
+                "resistance": self.S_R_zeta,
+                "inductance": self.S_L_zeta,
+                "capacitance": self.S_C_zeta
             },
             "scalar_sensitivities": {
-                "R": self.scalar_R,
-                "L": self.scalar_L,
-                "C": self.scalar_C
+                "resistance": self.scalar_R,
+                "inductance": self.scalar_L,
+                "capacitance": self.scalar_C
             },
             "most_sensitive_parameter": self.most_sensitive_parameter,
             "condition_number": self.condition_number,
@@ -1710,6 +1710,16 @@ class LaplaceOracle:
     # MÉTODOS DE ANÁLISIS
     # ─────────────────────────────────────────────────────────────────────────
     
+    def calculate_parametric_sensitivities(self) -> Dict[str, Any]:
+        """
+        Calcula el tensor de sensibilidades paramétricas en formato canónico.
+
+        Mide el impacto de las variaciones de R, L y C sobre los autoestados
+        del sistema (ωₙ, ζ).
+        """
+        sensitivity_matrix = self._sensitivity_calc.calculate_sensitivity_matrix()
+        return sensitivity_matrix.to_dict()
+
     def analyze_stability(self) -> Dict[str, Any]:
         """
         Análisis completo de estabilidad del sistema.

--- a/tests/unit/core/test_mic_lateral.py
+++ b/tests/unit/core/test_mic_lateral.py
@@ -715,14 +715,10 @@ class TestVectorLateralPivot:
               - Valores None inesperados
               - Estructuras incompletas
             """
-            try:
-                result = vector_lateral_pivot(payload)
-                assert result["success"] is False, (
-                    f"Payload malformado aceptado incorrectamente: {description}"
-                )
-            except (TypeError, KeyError, AttributeError) as e:
-                # Excepciones explícitas son aceptables para inputs muy corruptos
-                pytest.skip(f"Excepción aceptable para {description}: {type(e).__name__}")
+            result = vector_lateral_pivot(payload)
+            assert result["success"] is False, (
+                f"Payload malformado aceptado incorrectamente: {description}"
+            )
 
 
 # =============================================================================

--- a/tests/unit/physics/test_class_maxwell.py
+++ b/tests/unit/physics/test_class_maxwell.py
@@ -137,6 +137,13 @@ def octahedron() -> Dict[int, Set[int]]:
 
 
 @pytest.fixture
+def maxwell_solver(single_triangle) -> MaxwellFDTDSolver:
+    """Fixture para un solver de Maxwell base."""
+    calc = DiscreteVectorCalculus(single_triangle)
+    return MaxwellFDTDSolver(calc)
+
+
+@pytest.fixture
 def grid_2x2() -> Dict[int, Set[int]]:
     """Malla 2x2 triangulada."""
     # Nodos: 0-1-2
@@ -328,19 +335,19 @@ class TestBoundaryOperators:
             assert np.sum(column == -1) == 1
             assert np.sum(column == 0) == calc.num_nodes - 2
 
-    def test_boundary2_column_sum_zero(self, single_triangle):
+    def test_cochain_complex_exactness(self, maxwell_solver: MaxwellFDTDSolver) -> None:
         """
-        Cada columna de ∂₂ debe sumar 0 (∂[σ] es ciclo cerrado).
-        NOTA: Esto solo es cierto si las aristas se orientan para formar un ciclo aditivo.
-        En la práctica, la suma de coeficientes depende de la orientación relativa.
-        Se omite este test estricto en favor de boundary1 @ boundary2 == 0.
+        Axioma Topológico: El borde de un borde es el conjunto vacío (d_1 ∘ d_2 = 0).
+        Verifica que la matriz de incidencia B1 y la matriz de ciclos B2 son ortogonales.
         """
-        pytest.skip("La suma de coeficientes de columna no es 0 para un triángulo simple en esta base")
-        calc = DiscreteVectorCalculus(single_triangle)
+        B1 = maxwell_solver.calc.boundary1  # Matriz Nodos x Aristas
+        B2 = maxwell_solver.calc.boundary2  # Matriz Aristas x Caras
 
-        if calc.num_faces > 0:
-            col_sums = np.array(calc.boundary2.sum(axis=0)).flatten()
-            # np.testing.assert_allclose(col_sums, 0, atol=1e-14)
+        # La norma de Frobenius del producto debe colapsar asintóticamente al cero
+        producto = B1 @ B2
+        norma_frob = sparse_norm(producto)
+        assert norma_frob < 1e-12, \
+            f"Fuga dimensional: La variedad no es cerrada. Norma: {norma_frob}"
 
     def test_boundary_composition_zero(self, tetrahedron):
         """∂₁ ∘ ∂₂ = 0 (propiedad fundamental de complejos de cadenas)."""

--- a/tests/unit/strategy/test_laplace_oracle.py
+++ b/tests/unit/strategy/test_laplace_oracle.py
@@ -633,19 +633,14 @@ class TestParameterSensitivity:
 
     def test_zeta_sensitivity_to_R_is_unity(self, underdamped_oracle):
         """Verifica S_R^ζ = 1 (sensibilidad normalizada de ζ a R)."""
-        stability = underdamped_oracle.analyze_stability()
-        sensitivity = stability["parameter_sensitivity"]
+        sensitivity_tensor = underdamped_oracle.calculate_parametric_sensitivities()
         
-        # Buscar sensibilidad de ζ a R
-        if "sensitivity_matrix" in sensitivity:
-            s_r_zeta = sensitivity["sensitivity_matrix"].get("R", {}).get("zeta", None)
-        elif "normalized_sensitivities" in sensitivity:
-            s_r_zeta = sensitivity["normalized_sensitivities"]["zeta"]["R"]
-        else:
-            pytest.skip("Formato de sensibilidad no reconocido")
+        # Extraer específicamente S_R^zeta garantizando la navegación del formato canónico
+        s_r_zeta = sensitivity_tensor.get("damping_ratio", {}).get("resistance", None)
         
-        if s_r_zeta is not None:
-            assert_close(s_r_zeta, 1.0, rtol=0.01, msg="S_R^ζ debe ser 1")
+        assert s_r_zeta is not None, "Contrato roto: Falta el vector de sensibilidad de la resistencia."
+        assert math.isclose(s_r_zeta, 1.0, rel_tol=1e-5), \
+            f"Violación de sensibilidad paramétrica. Esperado 1.0, obtenido: {s_r_zeta}"
 
     def test_robustness_classification_exists(self, underdamped_oracle):
         """Verifica que existe clasificación de robustez."""


### PR DESCRIPTION
This PR restores the integrity of the Port-Hamiltonian test suite by eliminating technical debt hidden under `pytest.skip`.

### Key Improvements:
- **Topological Invariants:** Corrected the expectation for the second boundary operator ∂₂. In Discrete Exterior Calculus, the composite morphism ∂₁ ∘ ∂₂ must be null, which is now rigorously verified.
- **Canonical Sensitivities:** Standardized the sensitivity tensor output in `LaplaceOracle` to use full semantic names (e.g., `damping_ratio`, `resistance`), ensuring a stable contract for strategic audits.
- **Monadic Error Handling:** Reinforced the `vector_lateral_pivot` adapter with robust type checking. It now intercepts malformed payloads (None or incorrect types) and returns a formal failure result, aligning with aero-space grade reliability standards.

### Verification:
- `tests/unit/physics/test_class_maxwell.py`: 105 passed.
- `tests/unit/strategy/test_laplace_oracle.py`: 101 passed.
- `tests/unit/core/test_mic_lateral.py`: 230 passed.

---
*PR created automatically by Jules for task [1299031200318379788](https://jules.google.com/task/1299031200318379788) started by @Gerard003-ecu*