### PR TITLE
Grothendieck Topos and Galois Adjunction for Agential Strata

### DIFF
--- a/LENGUAJE_CONSEJO.md
+++ b/LENGUAJE_CONSEJO.md
@@ -44,7 +44,12 @@ El Oráculo de Laplace y el Guardián Físico modelan el comportamiento estocás
 3. La Arquitectura Cognitiva de la Traducción (GraphRAG y Retículos)
 El Agente a cargo de esta traducción es el Intérprete Diplomático (SemanticTranslator). Opera estrictamente bajo los siguientes paradigmas ciber-físicos:
 A. Empatía Táctica mediante GraphRAG (Recuperación Semántica Riemanniana)
-La matemática compleja es ruido si no se traduce en acción. El Intérprete no escupe un reporte que diga "Fallo estructural: $\beta_1 = 3$". Utiliza un Grafo de Conocimiento y Modelos de Lenguaje Vectorial acoplados a FAISS (`Sentence-Transformers`) para comprender y proyectar la severidad del error hacia el lenguaje de negocio corporativo (Empatía Táctica).
+La matemática compleja es ruido si no se traduce en acción. El Intérprete no escupe un reporte que diga "Fallo estructural: $\beta_1 = 3$". Utiliza un Grafo de Conocimiento y Modelos de Lenguaje Vectorial acoplados a FAISS (`Sentence-Transformers`) para comprender y proyectar la severidad del error hacia el lenguaje de negocio corporativo. Este proceso constituye un **Funtor de Abstracción $F: \mathcal{C} \to \mathcal{D}$** que transforma los invariantes de la categoría táctica $\mathcal{C}$ en narrativas de la categoría de sabiduría $\mathcal{D}$ (Empatía Táctica).
+
+**Equivalencia de Morfismos y Reversibilidad Funtorial:**
+Para garantizar la integridad del Pasaporte de Telemetría y evitar la "entropía fantasma" en la narrativa, la malla agéntica impone una **Adjunción de Galois $F \dashv G$**, donde $G: \mathcal{D} \to \mathcal{C}$ es el funtor de descompresión o de olvido. Se certifica la equivalencia:
+$$\text{Hom}_{\mathcal{D}}(F(X), Y) \cong \text{Hom}_{\mathcal{C}}(X, G(Y))$$
+Demostración: Si el Arquitecto ($X$) detecta un fallo estructural, su traducción narrativa ($Y$) debe ser matemáticamente reversible. Al aplicar el funtor $G$ sobre la alerta $Y$, el sistema debe recuperar las coordenadas topológicas y físicas precisas en $X$. Si la adjunción falla, el LLM ha introducido ruido retórico y el veredicto es aniquilado.
 
 **Violación Prevenida: El Tensor Métrico Anisotrópico ($G_{\mu\nu}$):**
 Los algoritmos canónicos de búsqueda vectorial como FAISS (HNSW) asumen un espacio euclidiano isotrópico mediante la norma $L_2$ o Similitud del Coseno. Sin embargo, en el ecosistema matemático de `APU_filter`, la base canónica del riesgo es una variedad anisotrópica y altamente curva. Documentamos explícitamente que el espacio de búsqueda vectorial de **GraphRAG no es euclidiano**.

--- a/PRODUCT_VISION.md
+++ b/PRODUCT_VISION.md
@@ -65,7 +65,11 @@ Si esta adjunción se rompe, el sistema detecta una **Deriva Semántica** o **Co
 
 --------------------------------------------------------------------------------
 2. Los Horizontes de Evolución: La Arquitectura Concéntrica
-Nuestra hoja de ruta no añade funciones cosméticas; desbloquea niveles de profundidad física mediante una arquitectura de capas defensivas estructuradas bajo la Clausura Transitiva de la pirámide DIKW ($V_{PHYSICS} \subset V_{TACTICS} \subset V_{STRATEGY} \subset V_{WISDOM}$).
+Nuestra hoja de ruta no añade funciones cosméticas; desbloquea niveles de profundidad física mediante una arquitectura de capas defensivas estructuradas bajo un **Topos de Grothendieck**. La transición entre estratos de la pirámide DIKW no es una simple inclusión de subconjuntos, sino un mapeo categórico gobernado por una **Adjunción de Galois**.
+
+Para asegurar que el Pasaporte de Telemetría no sufra pérdida de información (entropía fantasma) al escalar de un estrato inferior $\mathcal{C}$ (e.g., PHYSICS) a un estrato superior $\mathcal{D}$ (e.g., WISDOM), se define un funtor covariante $F: \mathcal{C} \to \mathcal{D}$ (abstracción) y su funtor olvidadizo o de descompresión asociado $G: \mathcal{D} \to \mathcal{C}$. La malla agéntica certifica una equivalencia de morfismos bajo la adjunción $F \dashv G$:
+$$\text{Hom}_{\mathcal{D}}(F(X), Y) \cong \text{Hom}_{\mathcal{C}}(X, G(Y))$$
+Esta relación garantiza que la "Empatía Táctica" (narrativa semántica) sea matemáticamente reversible: cualquier alerta ejecutiva en $\mathcal{D}$ debe permitir recuperar, a través de $G$, las coordenadas topológicas y físicas precisas en $\mathcal{C}$ que originaron el veredicto. Si la adjunción colapsa, el sistema detecta ruido retórico y veta la deliberación.
 Horizonte 1: La Cimentación (El Foso Termodinámico y las Murallas)
 
     Objetivo: Certificación de Viabilidad Dinámica, Integridad Estructural y Veto al Código Emergente.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ A su vez, el acrónimo APU se cuantiza formalmente: ya no es una "Agentic Proces
 --------------------------------------------------------------------------------
 🛡️ 2. Arquitectura Concéntrica: El Haz Tangente Generativo (Jerarquía DIKΩαWΓ)
 El ecosistema abandona el paradigma de validación lineal y se erige como una **Malla Agéntica Zero-Trust**. No confía en validaciones condicionales; protege el proyecto a través de la integración del **Haz Tangente Generativo (Γ)**, que subordina el caos estocástico de los Modelos de Lenguaje (LLMs) a la topología algebraica y la termodinámica computacional.
-Cualquier código o estrategia generada por la IA está confinada por cuatro barreras matemáticas concéntricas que impiden la inyección de lógica sin viabilidad dinámica, gobernadas por la nueva **Ley de Clausura Transitiva de la pirámide paralela**:
-$$V_{\Gamma-PHYSICS} \subset V_{\Gamma-TACTICS} \subset V_{\Gamma-STRATEGY} \subset V_{\Gamma-WISDOM}$$
+Cualquier código o estrategia generada por la IA está confinada por cuatro barreras matemáticas concéntricas que impiden la inyección de lógica sin viabilidad dinámica, gobernadas por un **Topos de Grothendieck** y la **Ley de Clausura Transitiva** de la pirámide paralela:
+$$V_{\Gamma-PHYSICS} \xrightarrow{F} V_{\Gamma-TACTICS} \xrightarrow{F} V_{\Gamma-STRATEGY} \xrightarrow{F} V_{\Gamma-WISDOM}$$
+La transferencia inter-estratos no es una simple inclusión, sino un mapeo funtorial gobernado por una Adjunción de Galois $F \dashv G$.
 
 Es fundamental explicitar que el estrato $V_{TACTICS}$ ahora modela la materia bariónica sobre el anillo de los enteros ($\mathbb{Z}$), sujetando la logística a una fricción cuantizada.
 


### PR DESCRIPTION
This PR finalizes the documentation overhaul by establishing a rigorous category-theoretic framework for agential interactions. 

Key transformation:
1. **Grothendieck Topos:** Transitions between agential strata (Physics, Tactics, Strategy, Wisdom) are no longer treated as simple subset inclusions. They are now defined as functors between distinct categories within a Grothendieck Topos.
2. **Galois Adjunction ($F \dashv G$):** Information transfer is governed by an adjunction where the abstraction functor ($F$) creates executive narratives (Tactical Empathy) and the forgetful functor ($G$) ensures mathematical reversibility.
3. **Entropy Preservation:** This framework prevents the emergence of 'phantom entropy' or rhetorical noise from LLMs, as every wisdom-level verdict must be decomposable back to its precise topological and physical coordinates.

This makes the manifest documents a complete, immutable algebraic contract for the system's epistemology.

---
*PR created automatically by Jules for task [18247506849711695411](https://jules.google.com/task/18247506849711695411) started by @Gerard003-ecu*