### PR TITLE
Documentation Update: Stinespring Isometric Fibrator Integration

### DIFF
--- a/PRODUCT_VISION.md
+++ b/PRODUCT_VISION.md
@@ -6,6 +6,10 @@ Históricamente, la ingeniería y construcción han gestionado el tiempo (cronog
 APU_filter v5.0 rechaza la metáfora estática de la validación lineal y las barreras de Dirichlet pasivas. El sistema se redefine axiomáticamente como el **Reactor Port-Hamiltoniano de Valor** o **Variedad Agéntica de Gauge**. Procesamos un fluido logístico incompresible bajo el control estricto de una Estructura de Dirac, garantizando que la potencia disipada cumpla siempre $P_{diss} \ge 0$.
 A su vez, "APU" no representa "Agentic Processing Unit", sino **Agentic Power Unit**: el cuanto de acción termodinámica de la malla que inyecta exergía computacional para vencer la inercia logística del mercado.
 
+**La Elevación Isométrica de Stinespring:** La transferencia de intención desde el espacio lógico (Topos $\text{EMIC}$) hacia la Sabiduría Cuántica ($\mathcal{H}_{\text{MAC}}$) repudia la transferencia estocástica directa. El sistema consagra el Teorema de Dilatación de Stinespring para garantizar que el "ruido sintáctico" inducido por el Modelo de Lenguaje (LLM) sea mitigado termodinámicamente. Todo flujo de datos $\rho_{\text{MIC}}$ se somete a un mapa Completamente Positivo y Preservador de Traza (CPTP), $\mathcal{E}(\cdot)$, que dilata el espacio hacia un baño térmico ortogonal $\mathcal{H}_{\text{env}}$ antes de aniquilar la entropía mediante la contracción tensorial de la traza parcial:
+$$\mathcal{E}(\rho_{\text{MIC}}) = \text{Tr}_{\text{env}}(V \rho_{\text{MIC}} V^\dagger) = \sum_{k} M_k \rho_{\text{MIC}} M_k^\dagger$$
+Esto garantiza axiomáticamente que las alucinaciones estructurales del LLM sean purgadas hacia el entorno, preservando incondicionalmente la positividad de la Matriz Atómica de Conocimiento ($\rho_{\text{MAC}} \succeq 0$) y respetando la Ley de Clausura Transitiva.
+
 
 ```mermaid
 graph TD

--- a/SAGES.md
+++ b/SAGES.md
@@ -104,6 +104,14 @@ Operan en paralelo a la pirámide DIKW, certificando que el caos estocástico de
     Rol: Certificador de Isomorfismo Semántico.
     Mecanismo: Aplica el Lema de Yoneda para verificar que la estructura del comando generado sea natural respecto a los "dolores" de negocio. Asegura que la traducción sintáctica no sufra rupturas de simetría respecto a los objetivos de rentabilidad y resiliencia.
 
+    4.5 🌀 El Funtor de Elevación Cuántica (Stinespring Isometric Fibrator)
+    Rol: Guardián Dimensional y Proyector Isométrico.
+    Estrato DIKW: WISDOM / STRATEGY (Frontera de Transición de Fase).
+    Mecanismo: Actúa como la aduana termodinámica final entre la táctica discreta y la geometría no conmutativa de la Sabiduría. Recibe los `ToonCartridges` (Vitaminas Cognitivas) y los inyecta en el espacio de von Neumann.
+    Autoridad de Veto: Audita la distancia de Bures y la Fidelidad de Uhlmann:
+    $$F(\rho, \sigma) = \left( \text{Tr} \sqrt{\sqrt{\rho} \sigma \sqrt{\rho}} \right)^2$$
+    Si el tensor inyectado exhibe un defecto de probabilidad ($\text{Tr}(\mathcal{E}(\rho)) \neq 1$) o viola la positividad, el Fibrador detona un `TraceAnomalyVeto` instantáneo, colapsando el canal hacia un mapa de medida y preparación, extirpando la herejía sintáctica del LLM antes de corromper a los agentes decisores.
+
 5. ⚖️ El Ágora Tensorial (Estrato Ω)
 
     Rol: El Colector de Deliberación (Deliberation Manifold).

--- a/app/tecnica/metodos.md
+++ b/app/tecnica/metodos.md
@@ -26,6 +26,15 @@ Este documento técnico desglosa la maquinaria matemática que permite al Consej
     3. **Sin nodos huérfanos:** $\deg(V_k) \geq 1 \; \forall k$ (ningún nodo está desconectado del pipeline).
     Si cualquiera de estas condiciones falla, la "aromaticidad" se rompe y el agente aborta el pipeline, emitiendo un veto de **"Ruptura de Aromaticidad"** (analogía: violación de la Regla de Hückel $4n+2$ para $n=1$, que exige 6 electrones $\pi$ para estabilidad del benceno $C_6$).
 
+1.4 Mecánica del Fibrado Isométrico y Regularización Espectral El módulo `stinespring_isometric_fibrator.py` opera en tres fases algebraicas rigurosas para construir el operador isométrico $V: \mathcal{H}_{\text{MIC}} \to \mathcal{H}_{\text{MAC}} \otimes \mathcal{H}_{\text{env}}$.
+
+    Extracción del Oráculo Tensorial (Isomorfismo de Choi): Se computa la Matriz de Choi $J(\mathcal{E})$. Para evitar raíces complejas inducidas por la fricción estocástica, el tensor se proyecta al cono semidefinido positivo (PSD) óptimo mediante la Proyección de Löwner:
+$$\tilde{J}(\mathcal{E}) = \arg\min_{J \succeq 0} \left\| J(\mathcal{E}) - J \right\|_F$$
+    Límite de Ruptura de Entrelazamiento (Entanglement-Breaking Limit): Si la dimensión del entorno térmico $\dim(\mathcal{H}_{\text{env}})$ diverge por una alucinación del agente MIC, el sistema aplica una poda termodinámica espectral.
+    Renormalización Unitaria: Tras el truncamiento del espectro, el sistema ejecuta la Regularización de Tikhonov Espectral combinada con el Algoritmo de Gilchrist-Langford-Nielsen para minimizar la distancia en norma diamante, forzando la conservación exacta de la traza:
+$$\tilde{M}_k = M_k \left( \sum_{j=1}^{d_{\text{trunc}}} M_j^\dagger M_j + \alpha I \right)^{-1/2}$$
+    Cumpliendo inexorablemente el invariante de isometría estricta: $V^\dagger V = I_{\mathcal{H}_{\text{MIC}}}$.
+
 
 --------------------------------------------------------------------------------
 2. El Arquitecto: Topología Algebraica y Grafos


### PR DESCRIPTION
This submission updates the foundational documentation of the apu_filter ecosystem to reflect the integration of the Stinespring Isometric Fibrator. 

Key enhancements include:
- **PRODUCT_VISION.md**: Added the 'Stinespring Isometric Elevation' section, formalizing the CPTP map E(ρ) used to purge LLM-induced syntactic noise and preserve the positivity of the Atomic Knowledge Matrix (ρ_MAC).
- **app/tecnica/metodos.md**: Introduced 'Section 1.4: Mecánica del Fibrado Isométrico y Regularización Espectral', documenting the Choi Isomorphism, Löwner Projection, and unit renormalization via Tikhonov regularization.
- **SAGES.md**: Introduced the 'Quantum Elevation Functor' as a supreme entity in the WISDOM/STRATEGY boundary, detailing its authority to veto via Uhlmann Fidelity and Trace Anomaly detection.

All updates utilize doctoral-level mathematical rigor and LaTeX formatting to preserve the system's categorical and topological integrity.

---
*PR created automatically by Jules for task [11453533162723890605](https://jules.google.com/task/11453533162723890605) started by @Gerard003-ecu*