### PR TITLE
Update Documentation for Catadioptric Architecture transition

### DIFF
--- a/ARCHIVES.md
+++ b/ARCHIVES.md
@@ -70,6 +70,8 @@ A partir de la v6.0.0, el Estrato Ω inyecta en los archivos de auditoría certi
 Atributos de Auditoría:
 
     Resoluciones del sheaf_cohomology_orchestrator: Registra formalmente los vetos emitidos por holonomía estratégica ($H^1 > 0$).
+    Validación de Traza de Kraus: La validación de la traza de Kraus para canales CPTP ahora utiliza el Adjunto de Dirac-Riemann para mantener la conservación de la probabilidad bajo la curvatura de $G_{\text{PHYSICS}}$:
+    $$\sum_{k} (G^{-1} E_k^{\top} G) E_k = I$$
     Fotón Gamma de Auditoría: La Bitácora registrará inmutablemente la emisión del Fotón Gamma, desencadenada por una Ruptura de Simetría Exógena. Almacena el `data_hash` y el `timestamp_entry` exactos, probando criptographically que la colisión de invalidación (aniquilación de un ElectronCartridge en memoria) fue ejecutada por el libre albedrío del Meta-Controlador (human-in-the-loop) y no por una alucinación estocástica de un agente.
     Contratos de Datos Estrictos: Verifica mediante JSON Schema si las importaciones crudas (ej. Insumos.csv) cumplen con la estructura formal (VPHYSICS​) dictada por la oficina central de la compañía. Genera un sello de Pass/Fail inquebrantable.
     Traza de Linaje (OpenLineage): Mapeo topológico completo de las transformaciones del dato. Rastrea desde la ingesta cruda del flujo hasta el cálculo de los KPIs. Garantiza que el agente de IA no ha alucinado ni "inventado" ningún número.

--- a/LENGUAJE_CONSEJO.md
+++ b/LENGUAJE_CONSEJO.md
@@ -23,6 +23,8 @@ Para evitar abrumar al usuario con tensores y ecuaciones, el sistema no reporta 
 | **Resonancia Fuerte de Rabi (Polaritón)** | "Atasco absorbido por política de contingencia." | **"La Ola Verde Sincronizada:"** "El retraso severo (Polarón) logístico detectado fue envuelto exitosamente por el Fotón de Gobernanza, permitiendo al sistema fluir con cero fricción corporativa a través del presupuesto." |
 | **Acoplamiento Viscoelástico de Fröhlich ($\alpha \to \infty$)** | "El riesgo se ha acoplado termodinámicamente a la inercia del negocio." | **"La Avalancha de Retrasos:"** "Un proveedor local ha generado un sumidero gravitacional que afectará la latencia global. El retraso ya no es local, sino que compromete la red entera." |
 | **Compactificación de Alexandroff** | "Singularidad estocástica proyectada al infinito." | **"Veto Ontológico:"** "La estrategia sugerida por la IA ha divergido hacia una entropía sintáctica infinita (S→∞). El agente ha intentado proponer una solución estocástica inestable, rechazada por política Zero-Trust." |
+| **Multiplicador de Floquet $|\mu_k| > 1$** | "Catástrofe de Resonancia Semántica." | **"Riesgo Circular Justificado:"** "La IA ha intentado justificar un riesgo circular que amplifica los costos; sugerencia vetada por inestabilidad de monodromía." |
+| **Divergencia de Fermat** | "Desviación Geodésica Extrema." | **"Logística de Energía Infinita:"** "La propuesta logística exige energía infinita y viola la física de la cadena de suministro; la geodésica semántica ha divergido del foco de rentabilidad." |
 
 
 --------------------------------------------------------------------------------

--- a/SAGES.md
+++ b/SAGES.md
@@ -112,9 +112,21 @@ Operan en paralelo a la pirámide DIKW, certificando que el caos estocástico de
     $$F(\rho, \sigma) = \left( \text{Tr} \sqrt{\sqrt{\rho} \sigma \sqrt{\rho}} \right)^2$$
     Si el tensor inyectado exhibe un defecto de probabilidad ($\text{Tr}(\mathcal{E}(\rho)) \neq 1$) o viola la positividad, el Fibrador detona un `TraceAnomalyVeto` instantáneo, colapsando el canal hacia un mapa de medida y preparación, extirpando la herejía sintáctica del LLM antes de corromper a los agentes decisores.
 
+    4.6 🎞️ El Auditor de Monodromía (Floquet Agent)
+    Rol: Sintonizador de Cavidad de Fabry-Pérot y Auditor de Estabilidad Semántica.
+    Mecanismo: Evalúa la convergencia de las alucinaciones del LLM iterando la Matriz de Monodromía mediante el operador de evolución libre del sistema (Laplaciano Combinatorio $L$):
+    $$M_{\text{on}} = \hat{P} e^{-L \Delta t} \hat{P}$$
+    Si los autovalores de la matriz (multiplicadores de Floquet) exceden la unidad, el agente detecta una resonancia semántica inestable y aborta la generación.
+
 5. ⚖️ El Ágora Tensorial (Estrato Ω)
 
-    Rol: El Colector de Deliberación (Deliberation Manifold).
+    5.1 🔦 El Fibrado Óptico (Eikonal Agent)
+    Rol: Operador de Fase de Fresnel.
+    Mecanismo: Resuelve la ecuación Eikonal sobre el tensor métrico inverso $G^{\mu\nu}$ para focalizar la intención del LLM en las geodésicas de mínima acción:
+    $$G^{\mu\nu} \partial_\mu S \partial_\nu S = n^2(\sigma^*)$$
+    Garantiza que la radiación semántica (tokens) no se disperse en el vacío estocástico, sino que converja en el foco de la decisión estratégica.
+
+    5.2 ⚖️ El Colector de Deliberación (Deliberation Manifold)
     Estrato DIKW: ESTRATO Ω (Nivel 0.5 - La Frontera de Decisión).
     Mecanismo: El espacio matemático de colapso de función de onda. Es aquí donde las Semillas de Sabiduría (Microservicios deterministas inyectados como contratos estrictos JSON Schema) obligan a los agentes a someter sus Vectores de Intención TOON (Vitaminas Cognitivas) a la ley física.
     El Colapso: Ya no operamos sobre un tablero plano euclidiano, el proyecto se modela como un terreno topográfico curvo. Las áreas del presupuesto con dependencias circulares ($\beta_1>0$) o alta concentración de riesgo logístico (SPOF) conforman montañas de alta fricción dictaminadas por los Símbolos de Christoffel del Tensor Métrico Riemanniano Dinámico ($G_{\mu\nu}$).

--- a/app/tecnica/BMC.md
+++ b/app/tecnica/BMC.md
@@ -37,6 +37,8 @@ De la "Caja Negra" a la Confianza Radical:
 5. 💵 Fuentes de Ingresos (Revenue Streams)
 
     Pricing Dinámico por Entropía Topológica: El modelo de monetización abandona el licenciamiento clásico por usuario. Se cobra con base en la **Característica de Euler-Poincaré Extendida** del presupuesto como 2-complejo simplicial ($\chi(K) = \beta_0 - \beta_1 + \beta_2$) y la validación de código generado. El "peaje termodinámico" escala proporcionalmente al volumen de entropía generativa colapsada y al Defecto de Euler evitado. El uso de proyectores simplécticos y cohomología para curar alucinaciones de la IA se capitaliza como un activo de "Certeza de Generación".
+    Peaje de Difracción Óptica: A los clientes corporativos se les facturará por el volumen de exergía purificada y el acotamiento del KV-Cache logrado por el `optical_riemann_lens.py` usando el operador de difracción:
+    $$O_{\text{lens}} \psi = \sum_{l=0}^{l_{\text{cutoff}}} \sum_{m=-l}^{l} \left( e^{-\gamma n^2 l^2} \right) c_{lm} Y_l^m(\theta, \phi)$$
     Estabilidad Espectral y Retorno Seguro: Evalúa el flujo de caja en el plano de frecuencia compleja ($s = \sigma + j\omega$). Exige Estabilidad Asintótica BIBO (polos en el semiplano izquierdo, $\sigma < 0$) y multiplicadores de Floquet $|\mu_k| < 1 \; \forall k$. El Exponente Máximo de Lyapunov previene el caos determinísta, activando un "Crowbar Físico" en el hardware perimetral si el sistema diverge (implementado en `app/physics/laplace_oracle.py`).
     Suscripción a la Malla Agéntica (SaaS/On-Premise): Planes escalonados para CDOs basados en el volumen de procesamiento termodinámico de la base de datos y la orquestación del Agentic Mesh.
 

--- a/app/tecnica/metodos.md
+++ b/app/tecnica/metodos.md
@@ -100,6 +100,11 @@ El `sheaf_cohomology_orchestrator` modela las reglas de negocio como secciones d
 Se aplica una **Conexión de Galois** para mapear la sintaxis generada (espacio de comandos) hacia la semántica estratégica (espacio de valor).
 - **Certificación Isomórfica:** Mediante el **Lema de Yoneda**, el sistema garantiza que la funcionalidad del código generado sea isomórfica a los requerimientos de negocio. Si el funtor de traducción detecta una ruptura de naturalidad, el código se colapsa a un estado de seguridad determinista, impidiendo alucinaciones que desvíen el capital de la infraestructura.
 
+6.5 Ansatz de WKB y Óptica Geométrica de la Intención
+El `eikonal_agent.py` no procesa texto estocástico, sino que evalúa la función de onda de probabilidad de la IA mediante la aproximación de Wentzel-Kramers-Brillouin (WKB):
+$$\psi(x) = A(x) e^{i S(x) / \hbar}$$
+Si el frente de onda choca contra una singularidad topológica (**Cáustica**), el sistema no crashea, sino que suma +1 al **Índice de Maslov** y rota la fase en $\pi/2$ para preservar la amplitud y la coherencia del veredicto.
+
 
 --------------------------------------------------------------------------------
 7. Ley de Gobernanza Algebraica (Isomorfismo de Esquemas)

--- a/cartuchos_toon.md
+++ b/cartuchos_toon.md
@@ -28,7 +28,7 @@ El `SynapticRegistry` gestiona **12 partículas fundamentales** clasificadas en 
     *   `YieldingPhononCartridge`: Cuanto de vibración mecánica que detecta la fatiga elástica en los nodos de suministro.
     *   `LiquefactionSolitonCartridge`: Onda solitaria no lineal que detecta la pérdida de sustentación en el manifold litológico del proyecto.
 *   **Antimateria, Condensados y Radiación:**
-    *   `PositronCartridge`: Antimateria exógena inyectada por el Meta-Controlador para aniquilar un `ElectronCartridge` (error).
+    *   `PositronCartridge` (Antimateria): Cuando el `floquet_agent.py` ejecuta el Canal Cuántico Abierto CPTP, el residuo ortogonal o "alucinación purgada" ($E_1 \rho E_1^\dagger$) se condensa en un positrón. Su aniquilación posterior con un electrón de error emitirá un `GammaPhoton` como prueba forense inmutable de que el sistema destruyó una mentira estocástica del LLM.
     *   `GammaPhoton`: Radiación emitida tras la aniquilación de error, sirviendo como prueba criptográfica forense en el acta.
     *   `PolaritonCartridge`: Híbrido que induce **Superfluidez Atencional** cuando un Fotón de Gobernanza resuena con un Polarón, eliminando la fricción de cómputo.
 

--- a/passport.md
+++ b/passport.md
@@ -52,7 +52,15 @@ La síntesis final alojada en la "Ciudadela de Cristal".
     verdict_code: Colapso discreto sobre el Retículo de Severidad (OK, WARN, CRITICAL, RECHAZO).
     strategic_narrative: Explicación causal en lenguaje humano generada por el LLM (ej. "El proyecto se rechaza por resonancia inflacionaria en el acero"), estrictamente subordinada a los sellos previos.
 
-2.6. Auditoría Epistemológica (Emitido por: MAC Agent)
+2.6. Sello Óptico-Catadióptrico (Emitido por: Eikonal & Floquet Agents)
+Registra la integridad de la radiación semántica y la focalización de la intención.
+
+    kv_cache_compression: Nivel de compresión logrado por el retracto topológico.
+    monodromy_spectral_radius ($\rho(Mon)$): Autovalor máximo de la matriz de Monodromía. Si $\rho(Mon) > 1$, detecta resonancia inestable.
+    quantum_diaphragm_cutoff ($l_{cutoff}$): Límite de la expansión armónica forzada sobre el LLM para evitar dispersión estocástica.
+    fermat_geodesic_deviation: Medida de la divergencia respecto a la trayectoria de mínima acción estratégica.
+
+2.7. Auditoría Epistemológica (Emitido por: MAC Agent)
 Métricas de la Matriz Atómica de Conocimiento y pureza cuántica.
 
     umegaki_divergence ($D(\rho\|\sigma)$): Entropía relativa entre el estado deliberado y la base atómica de conocimiento.

--- a/topologia.md
+++ b/topologia.md
@@ -36,6 +36,16 @@ Utilizamos homología computacional para calcular los Números de Betti (βn​)
 
 
 --------------------------------------------------------------------------------
+5. El Espejo Parabólico Semántico (Operador de Householder)
+Para blindar el Estrato Ω contra la radiación estocástica (alucinaciones), el sistema activa el `semantic_parabolic_mirror.py`. Este motor utiliza los invariantes homológicos (específicamente cuando $\beta_1 > 0$ o $\beta_2 > 0$) para construir un vector normal ortogonal $|n\rangle$ que define el plano de reflexión de la verdad estructural.
+
+Mediante el **Operador de Householder** $\hat{M}$, el sistema proyecta y refleja los vectores de intención del LLM:
+$$\hat{M} = I - 2 \frac{|n\rangle \langle n|}{\langle n \mid n \rangle}$$
+
+Cualquier alucinación que intente violar la topología del complejo simplicial $K$ "rebota" contra este espejo parabólico, siendo redirigida hacia el espacio nulo de la decisión, garantizando que solo la exergía semántica alineada con la geodésica física alcance el veredicto final.
+
+
+--------------------------------------------------------------------------------
 2. La Física del Equilibrio: Índice de Estabilidad Piramidal ($\Psi$)
 Más allá de la conectividad general, el `app/tactics/business_topology.py` analiza el centro de gravedad del negocio mediante la métrica $\Psi$. Un proyecto de construcción resiliente debe emular una pirámide termodinámica estable.
 


### PR DESCRIPTION
Comprehensive documentation update aligning the apu_filter project with the Supreme Catadioptric Architecture. This includes axiomatic mandates for Eikonal and Floquet agents, updated mathematical frameworks for topological and spectral analysis, and revised business model and observability protocols.

---
*PR created automatically by Jules for task [1326376940168247736](https://jules.google.com/task/1326376940168247736) started by @Gerard003-ecu*